### PR TITLE
Stop Tests from Creating Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Tests Passing](https://github.com/NicolaWealth/code_coverage_extractor/actions/workflows/auto_test_main_badge.yml/badge.svg)
 
 # Introduction
-The `Code Coverage Extractor` provides functionality to extract statement coverage for a given file(s) and output the data in a `Shields.io` dyanmic endpoint badge format. 
+The `Code Coverage Extractor` provides functionality to extract statement coverage for a given file(s) and output the data in a `Shields.io` dynamic endpoint badge format. 
 
 # Installation
 This package should be installed via npm. You must have npm installed first. The following can be run on the commandline to install the `Code Coverage Extractor` package with npm:

--- a/resources/test_badge.json
+++ b/resources/test_badge.json
@@ -1,5 +1,0 @@
-{
-  "label": "Coverage",
-  "message": "0%",
-  "color": "red"
-}

--- a/src/extract_coverage.test.ts
+++ b/src/extract_coverage.test.ts
@@ -5,84 +5,113 @@ import sinon from "sinon";
 
 describe("extract coverage tests", () => {
   let consoleLogStub: sinon.SinonStub;
-  let badgeData = JSON.parse(fs.readFileSync('./resources/test_badge.json', 'utf-8'));
   const outputFile = 'resources/test_badge.json';
 
+  const fileSystemStub = {
+    writeFileSync: sinon.stub()
+  };
+
   beforeEach(function() {
-    consoleLogStub = sinon.stub(console, 'log');
+    consoleLogStub = sinon.stub();
   });
 
   afterEach(function() {
-    consoleLogStub.restore();
+    consoleLogStub.reset();
+    fileSystemStub.writeFileSync.reset();
   });
 
   it("less than 50% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/failing_coverage.json', 'utf-8')), outputFile);
-    badgeData = JSON.parse(fs.readFileSync('./resources/test_badge.json', 'utf-8'));
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/failing_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
     assert(consoleLogStub.calledWith(0));
 
-    // Assert the badge data was updated appropriately
-    assert.strictEqual(badgeData.message, '0%');
-    assert.strictEqual(badgeData.color, 'red');
+    // Expected badge data passed through stub call
+    const badgeData = {
+      label: 'Coverage',
+      message: `0%`,
+      color: 'red'
+    };
+
+    // Assert expected badge data was passed
+    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("between 50% and 69% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/passing_coverage.json', 'utf-8')), outputFile);
-    badgeData = JSON.parse(fs.readFileSync('./resources/test_badge.json', 'utf-8'));
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/passing_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
     assert(consoleLogStub.calledWith(60));
 
-    // Assert the badge data was updated appropriately
-    assert.strictEqual(badgeData.message, '60%');
-    assert.strictEqual(badgeData.color, 'yellow');
+    // Expected badge data passed through stub call
+    const badgeData = {
+      label: 'Coverage',
+      message: `60%`,
+      color: 'yellow'
+    };
+
+    // Assert expected badge data was passed
+    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("between 70% and 89% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/high_coverage.json', 'utf-8')), outputFile);
-    badgeData = JSON.parse(fs.readFileSync('./resources/test_badge.json', 'utf-8'));
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/high_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
     assert(consoleLogStub.calledWith(80));
 
-    // Assert the badge data was updated appropriately
-    assert.strictEqual(badgeData.message, '80%');
-    assert.strictEqual(badgeData.color, 'yellowgreen');
+    // Expected badge data passed through stub call
+    const badgeData = {
+      label: 'Coverage',
+      message: `80%`,
+      color: 'yellowgreen'
+    };
+
+    // Assert expected badge data was passed
+    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("greater than 89% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/full_coverage.json', 'utf-8')), outputFile);
-    badgeData = JSON.parse(fs.readFileSync('./resources/test_badge.json', 'utf-8'));
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/full_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
     assert(consoleLogStub.calledWith(100));
 
-    // Assert the badge data was updated appropriately
-    assert.strictEqual(badgeData.message, '100%');
-    assert.strictEqual(badgeData.color, 'brightgreen');
+    // Expected badge data passed through stub call
+    const badgeData = {
+      label: 'Coverage',
+      message: `100%`,
+      color: 'brightgreen'
+    };
+
+    // Assert expected badge data was passed
+    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("no statement map", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/no_statementmap.json', 'utf-8')), outputFile);
-    badgeData = JSON.parse(fs.readFileSync('./resources/test_badge.json', 'utf-8'));
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/no_statementmap.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
     assert(consoleLogStub.calledWith(0));
 
-    // Assert the badge data was updated appropriately
-    assert.strictEqual(badgeData.message, '0%');
-    assert.strictEqual(badgeData.color, 'red');
+    // Expected badge data passed through stub call
+    const badgeData = {
+      label: 'Coverage',
+      message: `0%`,
+      color: 'red'
+    };
+
+    // Assert expected badge data was passed
+    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 });

--- a/src/extract_coverage.test.ts
+++ b/src/extract_coverage.test.ts
@@ -7,9 +7,21 @@ describe("extract coverage tests", () => {
   let consoleLogStub: sinon.SinonStub;
   const outputFile = 'resources/test_badge.json';
 
-  const fileSystemStub = {
-    writeFileSync: sinon.stub()
-  };
+  // Create a stub to override the writeFileSync function of a fileSystem
+  const writeFileSync: sinon.SinonStub = sinon.stub();
+
+  // Create a proxy which can override the specific function fileSystem when it's called
+  const fsProxy = new Proxy(fs as { [key: string]: any; [key: symbol]: any }, {
+    get(target, prop) {
+      if (prop === 'writeFileSync') {
+        return writeFileSync;
+      }
+      return target[prop];
+    }
+  });
+
+  // Use the proxy with to create a fileSystemStub object with the type of fileSystem but with the proxy override method
+  const fileSystemStub = fsProxy as typeof fs & { writeFileSync: sinon.SinonStub };
 
   beforeEach(function() {
     consoleLogStub = sinon.stub();

--- a/src/extract_coverage.test.ts
+++ b/src/extract_coverage.test.ts
@@ -20,21 +20,18 @@ describe("extract coverage tests", () => {
     }
   });
 
-  // Use the proxy with to create a fileSystemStub object with the type of fileSystem but with the proxy override method
-  const fileSystemStub = fsProxy as typeof fs & { writeFileSync: sinon.SinonStub };
-
   beforeEach(function() {
     consoleLogStub = sinon.stub();
   });
 
   afterEach(function() {
     consoleLogStub.reset();
-    fileSystemStub.writeFileSync.reset();
+    fsProxy.writeFileSync.reset();
   });
 
   it("less than 50% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/failing_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/failing_coverage.json', 'utf-8')), outputFile, consoleLogStub, fsProxy as typeof fs);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
@@ -48,12 +45,12 @@ describe("extract coverage tests", () => {
     };
 
     // Assert expected badge data was passed
-    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
+    sinon.assert.calledOnceWithExactly(fsProxy.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("between 50% and 69% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/passing_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/passing_coverage.json', 'utf-8')), outputFile, consoleLogStub, fsProxy as typeof fs);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
@@ -67,12 +64,12 @@ describe("extract coverage tests", () => {
     };
 
     // Assert expected badge data was passed
-    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
+    sinon.assert.calledOnceWithExactly(fsProxy.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("between 70% and 89% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/high_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/high_coverage.json', 'utf-8')), outputFile, consoleLogStub, fsProxy as typeof fs);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
@@ -86,12 +83,12 @@ describe("extract coverage tests", () => {
     };
 
     // Assert expected badge data was passed
-    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
+    sinon.assert.calledOnceWithExactly(fsProxy.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("greater than 89% coverage", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/full_coverage.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/full_coverage.json', 'utf-8')), outputFile, consoleLogStub, fsProxy as typeof fs);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
@@ -105,12 +102,12 @@ describe("extract coverage tests", () => {
     };
 
     // Assert expected badge data was passed
-    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
+    sinon.assert.calledOnceWithExactly(fsProxy.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 
   it("no statement map", async () => {
     // Read fake coverage output and update badge data
-    extractCoverage(JSON.parse(fs.readFileSync('./resources/no_statementmap.json', 'utf-8')), outputFile, consoleLogStub, fileSystemStub);
+    extractCoverage(JSON.parse(fs.readFileSync('./resources/no_statementmap.json', 'utf-8')), outputFile, consoleLogStub, fsProxy as typeof fs);
 
     // Assert the console logged coverage value is correct
     assert(consoleLogStub.calledOnce);
@@ -124,6 +121,6 @@ describe("extract coverage tests", () => {
     };
 
     // Assert expected badge data was passed
-    sinon.assert.calledOnceWithExactly(fileSystemStub.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
+    sinon.assert.calledOnceWithExactly(fsProxy.writeFileSync, outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
   });
 });

--- a/src/extract_coverage.ts
+++ b/src/extract_coverage.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 
-export const extractCoverage = (coverageData: any, outputFile: any, log = console.log, fileSystem: typeof fs = fs) => {
+export const extractCoverage = (coverageData: ReturnType<typeof JSON.parse>, outputFile: fs.PathOrFileDescriptor, log: typeof console.log = console.log, fileSystem: typeof fs = fs) => {
   let totalStatements = 0;
   let coveredStatements = 0;
   let coveragePercentage = 0;

--- a/src/extract_coverage.ts
+++ b/src/extract_coverage.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 
-export const extractCoverage = (coverageData: any, outputFile: any) => {
+export const extractCoverage = (coverageData: any, outputFile: any, log = console.log, fileSystem: any = fs) => {
   let totalStatements = 0;
   let coveredStatements = 0;
   let coveragePercentage = 0;
@@ -11,7 +11,6 @@ export const extractCoverage = (coverageData: any, outputFile: any) => {
     if(!statementMap) continue;
     totalStatements += Object.keys(statementMap).length;
     coveredStatements += (Object.values(statementMap) as number[]).filter((value) => value > 0).length;
-
   }
 
   if (totalStatements > 0) {
@@ -27,10 +26,8 @@ export const extractCoverage = (coverageData: any, outputFile: any) => {
           'red'
   };
 
-  fs.writeFileSync(outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
+  fileSystem.writeFileSync(outputFile, JSON.stringify(badgeData, null, 2), 'utf-8');
 
-  console.log(coveragePercentage);
+  // Console log is used in the GitHub Actions environment to obtain the coveragePercentage value as an environment variable
+  log(coveragePercentage);
 }
-
-
-

--- a/src/extract_coverage.ts
+++ b/src/extract_coverage.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 
-export const extractCoverage = (coverageData: any, outputFile: any, log = console.log, fileSystem: any = fs) => {
+export const extractCoverage = (coverageData: any, outputFile: any, log = console.log, fileSystem: typeof fs = fs) => {
   let totalStatements = 0;
   let coveredStatements = 0;
   let coveragePercentage = 0;


### PR DESCRIPTION
add stubs to tests to avoid creating files in a testing setting and update documentation